### PR TITLE
feat: resize chart with flexible height

### DIFF
--- a/iclassi/sankey.js
+++ b/iclassi/sankey.js
@@ -148,7 +148,8 @@ function assertDAG(nodes, links) {
 }
 
 // ------- render (nodeAlign: 'right') -------
-const chart = echarts.init(document.getElementById('chart'), null, { useDirtyRect: true });
+const chartEl = document.getElementById('chart');
+const chart = echarts.init(chartEl, null, { useDirtyRect: true });
 
 function render(nodes, links) {
   assertDAG(nodes, links);
@@ -193,6 +194,7 @@ function render(nodes, links) {
 }
 
 window.addEventListener('resize', () => chart.resize());
+new ResizeObserver(() => chart.resize()).observe(chartEl);
 
 // ------- filter + download -------
 function filterGraph(nodes, links, q) {

--- a/iclassi/styles.css
+++ b/iclassi/styles.css
@@ -5,6 +5,10 @@
     box-sizing: border-box;
 }
 
+:root {
+    --chart-height: 100vh;
+}
+
 /* Ensure the body takes up the full height */
 html, body {
     height: 100%;
@@ -318,6 +322,6 @@ table {
 }
 #chart {
   width: 100%;
-  height: 80vh;   /* fills most of the viewport */
+  height: var(--chart-height, 100vh);   /* fills most of the viewport */
 }
 


### PR DESCRIPTION
## Summary
- allow chart height to be configured via CSS variable (default 100vh)
- resize ECharts instance whenever its container layout changes

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b59890b91c832aa96f91d7469b2a69