### PR TITLE
Enable depth-aware expansion in i-CLASSi Sankey

### DIFF
--- a/iclassi/index.html
+++ b/iclassi/index.html
@@ -51,6 +51,7 @@
     <button id="reset">Reset</button>
     <button id="download">Download PNG</button>
     <button id="fullscreen">Fullscreen</button>
+    <button id="collapse">Collapse All</button>
   </div>
 
   <div id="chart-container">


### PR DESCRIPTION
## Summary
- track node depth and children when building the Sankey graph
- limit initial render to `visibleDepth` and allow expanding nodes to reveal descendants
- add "Collapse All" control to reset expanded nodes

## Testing
- `node --check iclassi/sankey.js`


------
https://chatgpt.com/codex/tasks/task_e_68b5a8281f10832abc56398be8ff0270