### PR TITLE
Improve Sankey label layout to avoid overlaps

### DIFF
--- a/iclassi/sankey.js
+++ b/iclassi/sankey.js
@@ -282,17 +282,20 @@ function render(nodes, links) {
       }
     },
     animation: true,
-    series: [{
-      type: 'sankey',
-      nodeAlign: 'right',        
-      emphasis: { focus: 'trajectory' },
-      data: nodes,
-      links: links,
-      // do NOT set a series-level itemStyle.color — we want per-node colors to show
-      lineStyle: {
-            color: 'source',
-            curveness: 0.5
-          }
+      series: [{
+        type: 'sankey',
+        nodeAlign: 'right',
+        emphasis: { focus: 'trajectory' },
+        nodeGap: 8,
+        data: nodes,
+        links: links,
+        labelLayout: { hideOverlap: true },
+        label: { width: 120, fontSize: 12 },
+        // do NOT set a series-level itemStyle.color — we want per-node colors to show
+        lineStyle: {
+              color: 'source',
+              curveness: 0.5
+            }
       
     }]
   };


### PR DESCRIPTION
## Summary
- auto-hide intersecting Sankey labels via `labelLayout.hideOverlap`
- tweak label width, font size and node gap for better small screen display

## Testing
- `node <test-stub>`

------
https://chatgpt.com/codex/tasks/task_e_68b5ac71c12c832a8748f8605716e988