### PR TITLE
Add button to expand L5-L6 in Sankey graph

### DIFF
--- a/iclassi/index.html
+++ b/iclassi/index.html
@@ -48,10 +48,10 @@
     <label>Filter:
       <input id="filter" type="text" placeholder="e.g. follicular, HL, TFH"/>
     </label>
-    <button id="reset">Reset</button>
     <button id="download">Download PNG</button>
     <button id="fullscreen">Fullscreen</button>
     <button id="collapse">Collapse All</button>
+    <button id="expand56">Expand L5-L6</button>
   </div>
 
   <div id="chart-container">

--- a/iclassi/sankey.js
+++ b/iclassi/sankey.js
@@ -322,10 +322,6 @@ document.getElementById('filter').addEventListener('input', e => {
   const f = filterGraph(current.nodes, current.links, e.target.value || '');
   render(f.nodes, f.links);
 });
-document.getElementById('reset').addEventListener('click', () => {
-  document.getElementById('filter').value = '';
-  render(current.nodes, current.links);
-});
 document.getElementById('download').addEventListener('click', () => {
   const url = chart.getDataURL({ type: 'png', backgroundColor: '#ffffff' });
   const a = document.createElement('a'); a.href = url; a.download = 'ln-sankey.png'; a.click();
@@ -335,6 +331,13 @@ document.getElementById('download').addEventListener('click', () => {
 document.getElementById('collapse')?.addEventListener('click', () => {
   document.getElementById('filter').value = '';
   current = filterByDepth(fullGraph.nodes, fullGraph.links, visibleDepth);
+  render(current.nodes, current.links);
+});
+
+// show all L5/L6
+document.getElementById('expand56')?.addEventListener('click', () => {
+  document.getElementById('filter').value = '';
+  current = filterByDepth(fullGraph.nodes, fullGraph.links, 6);
   render(current.nodes, current.links);
 });
 


### PR DESCRIPTION
## Summary
- Remove redundant reset control
- Add dedicated "Expand L5-L6" button showing all level 5/6 nodes

## Testing
- `node -c iclassi/sankey.js`


------
https://chatgpt.com/codex/tasks/task_e_68b5ae8122d8832abea00985a4887696